### PR TITLE
Add stock price quote widget and styling improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,10 +40,15 @@ canvas{width:100%;height:100%;display:block;background:#fff}
 .src button{padding:6px 10px;border:1px solid var(--border);border-radius:8px;background:#fff;cursor:pointer}
 .note{color:#64748b;font-size:12px;margin-left:8px}
 .err{color:#991b1b}.ok{color:#047857}
+.quote-box{display:flex;gap:8px;align-items:center;padding:12px;background:linear-gradient(135deg,#e0f2fe,#fdf2f8);border-bottom:1px solid var(--border)}
+.quote-box input{flex:1;padding:6px 8px;border:1px solid var(--border);border-radius:8px}
+.quote-box button{padding:6px 10px;border:none;border-radius:8px;background:#2563eb;color:#fff;cursor:pointer}
+.quote-box .price{font-weight:700;min-width:80px;text-align:right}
 </style>
 </head>
 <body>
 <div class="wrap">
+  <div class="quote-box"><input id="quoteSymbol" type="text" placeholder="輸入股票代號，例如 0005.HK"><button id="btnQuote">查詢</button><div id="quotePrice" class="price"></div></div>
   <div class="toolbar">
     <div id="stateBadge" class="badge status">狀態：—</div>
     <div class="btns">
@@ -309,5 +314,31 @@ function initSrcUi(){
 })();
 btnReset.addEventListener('click',function(){ thrGEl.value=0.5; thrREl.value=-0.5; showBG.checked=true; showFused.checked=true; showHSI.checked=false; showHSTE.checked=false; showCNH.checked=false; showVHSI.checked=false; showBTC.checked=false; setWindowByPreset(30, rows.length); saveState(); });
 </script>
+
+<script>
+(async()=>{
+  const symbolInput=document.getElementById('quoteSymbol');
+  const btn=document.getElementById('btnQuote');
+  const priceEl=document.getElementById('quotePrice');
+  async function fetchQuote(sym){
+    const url=`https://query1.finance.yahoo.com/v7/finance/quote?symbols=${encodeURIComponent(sym)}`;
+    const r=await fetch(url);
+    const j=await r.json();
+    return j.quoteResponse.result[0]?.regularMarketPrice;
+  }
+  btn.addEventListener('click',async()=>{
+    const sym=symbolInput.value.trim();
+    if(!sym){ priceEl.textContent=''; return; }
+    priceEl.textContent='載入中...';
+    try{
+      const price=await fetchQuote(sym);
+      priceEl.textContent=price?price.toFixed(2):'N/A';
+    }catch(e){
+      priceEl.textContent='Error';
+    }
+  });
+})();
+</script>
+
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a stock quote widget that fetches prices from Yahoo Finance
- enhance page aesthetics with a gradient quote card and buttons

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b3b9a3390832eaf2e2968d2dd049e