### PR TITLE
feat: add loading overlay and error dialog

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,9 +40,11 @@ canvas{width:100%;height:100%;display:block;background:#fff}
 .src button{padding:6px 10px;border:1px solid var(--border);border-radius:8px;background:#fff;cursor:pointer}
 .note{color:#64748b;font-size:12px;margin-left:8px}
 .err{color:#991b1b}.ok{color:#047857}
+#loading{position:fixed;inset:0;background:rgba(255,255,255,.8);display:none;align-items:center;justify-content:center;z-index:9999;font-size:20px}
 </style>
 </head>
 <body>
+<div id="loading">載入中…</div>
 <div class="wrap">
   <div class="toolbar">
     <div id="stateBadge" class="badge status">狀態：—</div>
@@ -264,9 +266,13 @@ async function fetchGvizJson(url){
   }
   return out;
 }
+
+function showLoading(){ document.getElementById('loading').style.display='flex'; }
+function hideLoading(){ document.getElementById('loading').style.display='none'; }
+function showError(err){ const m=/(HTTP\s*(\d+))/.exec(err && err.message||''); const status=m?m[2]:'未知'; alert('抓取失敗 (HTTP '+status+')\n請檢查網址或稍後再試'); }
 async function reloadFromSource(){
   const input=(csvUrlEl.value||'').trim(); if(!input){ srcMsg.textContent='未設定來源，使用內嵌資料'; srcMsg.className='note'; rows=PRELOADED.rows.slice(); start=0; end=0; draw(); return; }
-  srcMsg.textContent='抓取中…'; srcMsg.className='note';
+  srcMsg.textContent='抓取中…'; srcMsg.className='note'; showLoading();
   try{
     const csvText=await fetchCsvText(input);
     const parsed=parseCsv(csvText);
@@ -281,9 +287,9 @@ async function reloadFromSource(){
     }catch(e2){
       console.error('CSV 錯誤:',e1,'GVIZ 錯誤:',e2);
       srcMsg.textContent='抓取失敗：' + (e2 && e2.message ? e2.message : (e1 && e1.message ? e1.message : '未知錯誤')) + '（已回退內嵌資料）'; srcMsg.className='note err';
-      rows=PRELOADED.rows.slice(); start=0; end=0; draw();
+      rows=PRELOADED.rows.slice(); start=0; end=0; draw(); showError(e2 || e1);
     }
-  }
+  } finally { hideLoading(); }
 }
 
 document.querySelectorAll('button[data-win]').forEach(function(btn){

--- a/index_full_v3f.html
+++ b/index_full_v3f.html
@@ -40,9 +40,11 @@ canvas{width:100%;height:100%;display:block;background:#fff}
 .src button{padding:6px 10px;border:1px solid var(--border);border-radius:8px;background:#fff;cursor:pointer}
 .note{color:#64748b;font-size:12px;margin-left:8px}
 .err{color:#991b1b}.ok{color:#047857}
+#loading{position:fixed;inset:0;background:rgba(255,255,255,.8);display:none;align-items:center;justify-content:center;z-index:9999;font-size:20px}
 </style>
 </head>
 <body>
+<div id="loading">載入中…</div>
 <div class="wrap">
   <div class="toolbar">
     <div id="stateBadge" class="badge status">狀態：—</div>
@@ -264,9 +266,13 @@ async function fetchGvizJson(url){
   }
   return out;
 }
+
+function showLoading(){ document.getElementById('loading').style.display='flex'; }
+function hideLoading(){ document.getElementById('loading').style.display='none'; }
+function showError(err){ const m=/(HTTP\s*(\d+))/.exec(err && err.message||''); const status=m?m[2]:'未知'; alert('抓取失敗 (HTTP '+status+')\n請檢查網址或稍後再試'); }
 async function reloadFromSource(){
   const input=(csvUrlEl.value||'').trim(); if(!input){ srcMsg.textContent='未設定來源，使用內嵌資料'; srcMsg.className='note'; rows=PRELOADED.rows.slice(); start=0; end=0; draw(); return; }
-  srcMsg.textContent='抓取中…'; srcMsg.className='note';
+  srcMsg.textContent='抓取中…'; srcMsg.className='note'; showLoading();
   try{
     const csvText=await fetchCsvText(input);
     const parsed=parseCsv(csvText);
@@ -281,9 +287,9 @@ async function reloadFromSource(){
     }catch(e2){
       console.error('CSV 錯誤:',e1,'GVIZ 錯誤:',e2);
       srcMsg.textContent='抓取失敗：' + (e2?.message || e1?.message || '未知錯誤') + '（已回退內嵌資料）'; srcMsg.className='note err';
-      rows=PRELOADED.rows.slice(); start=0; end=0; draw();
+      rows=PRELOADED.rows.slice(); start=0; end=0; draw(); showError(e2 || e1);
     }
-  }
+  } finally { hideLoading(); }
 }
 
 document.querySelectorAll('button[data-win]').forEach(btn=>{

--- a/index_full_v3f_fix2.html
+++ b/index_full_v3f_fix2.html
@@ -40,9 +40,11 @@ canvas{width:100%;height:100%;display:block;background:#fff}
 .src button{padding:6px 10px;border:1px solid var(--border);border-radius:8px;background:#fff;cursor:pointer}
 .note{color:#64748b;font-size:12px;margin-left:8px}
 .err{color:#991b1b}.ok{color:#047857}
+#loading{position:fixed;inset:0;background:rgba(255,255,255,.8);display:none;align-items:center;justify-content:center;z-index:9999;font-size:20px}
 </style>
 </head>
 <body>
+<div id="loading">載入中…</div>
 <div class="wrap">
   <div class="toolbar">
     <div id="stateBadge" class="badge status">狀態：—</div>
@@ -264,9 +266,13 @@ async function fetchGvizJson(url){
   }
   return out;
 }
+
+function showLoading(){ document.getElementById('loading').style.display='flex'; }
+function hideLoading(){ document.getElementById('loading').style.display='none'; }
+function showError(err){ const m=/(HTTP\s*(\d+))/.exec(err && err.message||''); const status=m?m[2]:'未知'; alert('抓取失敗 (HTTP '+status+')\n請檢查網址或稍後再試'); }
 async function reloadFromSource(){
   const input=(csvUrlEl.value||'').trim(); if(!input){ srcMsg.textContent='未設定來源，使用內嵌資料'; srcMsg.className='note'; rows=PRELOADED.rows.slice(); start=0; end=0; draw(); return; }
-  srcMsg.textContent='抓取中…'; srcMsg.className='note';
+  srcMsg.textContent='抓取中…'; srcMsg.className='note'; showLoading();
   try{
     const csvText=await fetchCsvText(input);
     const parsed=parseCsv(csvText);
@@ -281,9 +287,9 @@ async function reloadFromSource(){
     }catch(e2){
       console.error('CSV 錯誤:',e1,'GVIZ 錯誤:',e2);
       srcMsg.textContent='抓取失敗：' + (e2 && e2.message ? e2.message : (e1 && e1.message ? e1.message : '未知錯誤')) + '（已回退內嵌資料）'; srcMsg.className='note err';
-      rows=PRELOADED.rows.slice(); start=0; end=0; draw();
+      rows=PRELOADED.rows.slice(); start=0; end=0; draw(); showError(e2 || e1);
     }
-  }
+  } finally { hideLoading(); }
 }
 
 document.querySelectorAll('button[data-win]').forEach(function(btn){


### PR DESCRIPTION
## Summary
- show a loading overlay during data refresh
- hide overlay when fetch completes or fails
- alert users with HTTP status if reload fails

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b453a3144832eb8ab9dd34a533803